### PR TITLE
Update BatchSolve.jl Import AutoForwardFromPrimitive for the GPU newton default

### DIFF
--- a/src/BatchSolve.jl
+++ b/src/BatchSolve.jl
@@ -1,6 +1,6 @@
 module BatchSolve
 import DifferentiationInterface as DI
-using DifferentiationInterface: Constant, Cache, ConstantOrCache, Context
+using DifferentiationInterface: Constant, Cache, ConstantOrCache, Context, AutoForwardFromPrimitive
 using FiniteDiff: default_relstep, compute_epsilon
 using ADTypes: dense_ad
 import KernelAbstractions as KA


### PR DESCRIPTION

`newton` / `newton!` use `AutoForwardFromPrimitive` in the `autodiff` keyword
  default on the GPU branch (src/rootfinders/newton.jl:44 and :105):
  
      autodiff = KA.get_backend(x) isa KA.GPU ?
          AutoForwardFromPrimitive(AutoForwardDiff()) : AutoForwardDiff(),
          
  but src/BatchSolve.jl never brings `AutoForwardFromPrimitive` into scope — it
  only does `using DifferentiationInterface: Constant, Cache, ConstantOrCache,
  Context`. `AutoForwardFromPrimitive` is `@public` (not exported) in
  DifferentiationInterface, so `using DifferentiationInterface` alone doesn't
  import it.
  
  Result: any `newton` / `newton!` call with a GPU array and no explicit
  `autodiff=` throws `UndefVarError: AutoForwardFromPrimitive not defined in                                                                                                                                  
  BatchSolve`. This adds it to the existing explicit `using
  DifferentiationInterface:` list. 
  
  Found via SciBmad's `find_closed_orbit(...; batch=Val{true}(), v0::CuArray)`
  on an A100. Env: Julia 1.12.7, DifferentiationInterface 0.7.21, CUDA.jl 6.3.1.